### PR TITLE
skip check for 128x128 icon during build

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}


### PR DESCRIPTION
hi,

This will skip the check for icon (128x128) during the build process for Yaru-light

thanks!